### PR TITLE
Fix for Python 3.4: Header() takes a required positional argument.

### DIFF
--- a/wsgi_static_middleware.py
+++ b/wsgi_static_middleware.py
@@ -63,7 +63,7 @@ def _get_body(filename, method, block_size, charset):
 
 # View functions
 def static_file_view(env, start_response, filename, block_size, charset):
-    headers = Headers()
+    headers = Headers([])
 
     mimetype, encoding = mimetypes.guess_type(filename)
     headers.add_header('Content-Encodings', encoding)


### PR DESCRIPTION
The Headers() constructor's first argument (headers) is optional in Python >3.5, but in Python 3.4, it is required (compare https://docs.python.org/3.4/library/wsgiref.html#wsgiref.headers.Headers vs. https://docs.python.org/3.5/library/wsgiref.html#wsgiref.headers.Headers).

The simple fix is to provide an empty list, which is the default in Python >3.5.
